### PR TITLE
echo with space  and echo dolor solve

### DIFF
--- a/Makefile copy
+++ b/Makefile copy
@@ -1,0 +1,67 @@
+
+NAME = minishell
+
+CC = cc
+CFLAGS = -Wall -Wextra -Werror -g3
+
+LIBFT = libft/libft.a
+INCLUDES = -Iincludes
+LIBS = -lreadline
+RM = rm -f
+
+SRC_DIR = src
+OBJ_DIR = obj
+
+BUILT_DIR = $(SRC_DIR)/builtins
+PARSING_DIR = $(SRC_DIR)/parsing
+EXEC_DIR = $(SRC_DIR)/exec
+EXPAND_DIR = $(SRC_DIR)/expand
+UTILS_DIR = $(SRC_DIR)/utils
+TOKEN_DIR = $(SRC_DIR)/tokenizing
+
+BUILTINS    := $(BUILT_DIR)/echo.c $(BUILT_DIR)/cd.c \
+					$(BUILT_DIR)/pwd.c $(BUILT_DIR)/export.c \
+					$(BUILT_DIR)/env.c $(BUILT_DIR)/unset.c \
+					$(BUILT_DIR)/builtins_utils.c
+PARSING     := $(PARSING_DIR)/parse_pipeline.c
+EXEC        := $(EXEC_DIR)/exec_ast.c $(EXEC_DIR)/exec_builtins.c \
+					$(EXEC_DIR)/exec_path.c $(EXEC_DIR)/exec_heredoc.c
+
+EXPAND      := $(EXPAND_DIR)/expand_arg.c
+UTILS       := $(UTILS_DIR)/free.c $(UTILS_DIR)/fd.c $(UTILS_DIR)/error.c \
+					$(UTILS_DIR)/str.c
+
+TOKENIZING  := $(TOKEN_DIR)/token.c $(TOKEN_DIR)/token_utils.c $(TOKEN_DIR)/syntax_error.c \
+					$(TOKEN_DIR)/helper.c $(TOKEN_DIR)/extract_quoted.c
+COMMON      := $(SRC_DIR)/main.c $(SRC_DIR)/signal.c $(SRC_DIR)/init_ast.c \
+					$(SRC_DIR)/print_utils.c $(SRC_DIR)/init_mini.c $(SRC_DIR)/print_ast.c
+
+SRCS = $(BUILTINS) $(PARSING) $(EXEC) $(EXPAND) $(UTILS) $(TOKENIZING) $(COMMON)
+
+# Replace src/ → obj/ and .c → .o
+OBJS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
+
+all: $(NAME)
+
+$(NAME): $(LIBFT) $(OBJS)
+	$(CC) $(CFLAGS) $(INCLUDES) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME)
+
+# Create obj/... directory structure and compile
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+$(LIBFT):
+	@$(MAKE) -C libft
+
+clean:
+	$(RM) $(OBJS)
+	@$(MAKE) -C libft clean
+
+fclean: clean
+	$(RM) $(NAME)
+	@$(MAKE) -C libft fclean
+
+re: fclean all
+
+.PHONY: all clean fclean re

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -95,6 +95,14 @@ t_token	*create_t(char *str, t_quote_type quote_type);
 void	append_t(t_token **head, t_token *new);
 int		check_unclosed_quotes(const char *line);
 bool	check_syntax(t_token *tokens);
+//token_helper
+// int		is_meta_char(char c);
+// void	skip_spaces(const char *input, int *i);
+
+// char	*extract_plain(const char *input, int *i, char *current);
+// int		handle_meta(const char *input, int i, t_token **tokens);
+//extract_quoted.c
+// char	*extract_quoted(const char *input, int *i, char *current, t_quote_type *qt);
 
 
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -129,7 +129,8 @@ int		**create_heredoc_pipe(int heredoc_nb);
 void	close_all_heredocs(t_ast *ast);
 
 //expande
-char	*expand_arg(const char *str, t_mini *mini);
+//char	*expand_arg(const char *str, t_mini *mini);
+char *expand_arg(const char *str, t_mini *mini, t_quote_type quote_type);
 char	*expand_if_needed(t_token *token, t_mini *mini);
 char	*ft_strjoin_f(char *s1, char *s2);
 

--- a/libft/ft_strjoin.c
+++ b/libft/ft_strjoin.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/11 10:43:08 by hho-troc          #+#    #+#             */
-/*   Updated: 2024/11/11 14:33:22 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/08 13:37:15 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,5 +27,6 @@ char	*ft_strjoin(char const *s1, char const *s2)
 		s3[i++] = *s1++;
 	while (*s2)
 		s3[i++] = *s2++;
+	s3[i] = '\0';
 	return (s3);
 }

--- a/src/exec/exec_ast.c
+++ b/src/exec/exec_ast.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/18 20:06:06 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/04/23 17:05:29 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/08 10:06:40 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,9 +86,9 @@ void	handle_redirects(t_cmd *cmd)
 
 void	exec_cmd_node(t_ast *node, char **envp)
 {
-	int	i;
+	//int	i;
 
-	i = 0;
+	//i = 0;
 	if (!node->cmd)
 		return ;
 	handle_redirects(node->cmd);

--- a/src/exec/exec_heredoc.c
+++ b/src/exec/exec_heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec_heredoc.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ndabbous <ndabbous@student.42.fr>          #+#  +:+       +#+        */
+/*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025-04-25 13:06:45 by ndabbous          #+#    #+#             */
-/*   Updated: 2025-04-25 13:06:45 by ndabbous         ###   ########.fr       */
+/*   Created: 2025/04/25 13:06:45 by ndabbous          #+#    #+#             */
+/*   Updated: 2025/05/07 15:47:10 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ char	**get_heredoc(int nb, t_token *start, t_token *end, t_mini *mini)
 	{
 		if (tmp->type == HEREDOC && tmp->next)
 		{
-			tab_heredocs[i] = expand_arg(tmp->next->str, mini);
+			tab_heredocs[i] = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			tmp = tmp->next;
 			i++;
 		}

--- a/src/expand/expand_arg.c
+++ b/src/expand/expand_arg.c
@@ -6,11 +6,12 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/22 16:05:52 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/05/07 15:42:28 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/08 13:58:13 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+
 
 /* for "'$USER'" */
 char	*expand_if_needed(t_token *token, t_mini *mini)
@@ -55,6 +56,13 @@ static char	*expand_var(const char *str, int *i, t_mini *mini)
 	char	*val;
 
 	start = ++(*i); // skip $
+	if (str[start] == '"' || str[start] == '\'')
+	{
+		// Bash 中：$"" → 空變數（返回空字串）
+		(*i)++; // 前進 1 讓 tokenizer 不卡住
+		return (ft_strdup(""));
+	}
+
 	if (str[start] == '?')// $? is for exit code
 	//WEXITSTATUS(status) ????
 	{
@@ -64,6 +72,7 @@ static char	*expand_var(const char *str, int *i, t_mini *mini)
 	if (!str[start] || !(ft_isalpha(str[start]) || str[start] == '_'))
 	{
 		// echo $
+		//(*i)++; // for echo "$"""
 		return (ft_strdup("$"));
 	}
 	while (str[*i] && (ft_isalnum(str[*i]) || str[*i] == '_'))
@@ -73,46 +82,7 @@ static char	*expand_var(const char *str, int *i, t_mini *mini)
 	free(var);
 	return (val);
 }
-// char	*expand_arg(const char *str, t_mini *mini)
-// {
-// 	char	*result;
-// 	int		i = 0;
-// 	int		start;
-// 	//char	quote;
 
-// 	result = calloc(1, sizeof(char));
-// 	while (str[i])
-// 	{
-// 		if (str[i] == '\'') // single quote : copy raw
-// 		{
-// 			start = ++i;
-// 			while (str[i] && str[i] != '\'')
-// 				i++;
-// 			result = ft_strjoin_f(result, ft_strndup(str + start, i - start));
-// 			if (str[i] == '\'')
-// 				i++;
-// 		}
-// 		else if (str[i] == '"') // double quote : expand inside
-// 		{
-// 			start = ++i;
-// 			while (str[i] && str[i] != '"')
-// 			{
-// 				if (str[i] == '$')
-// 					result = ft_strjoin_f(result, expand_var(str, &i, mini));
-// 				else
-// 					result = ft_strjoin_f(result, ft_strndup(str + i++, 1));
-// 			}
-// 			if (str[i] == '"')
-// 				i++;
-// 		}
-// 		else if (str[i] == '$') // outside quote, expand
-// 			result = ft_strjoin_f(result, expand_var(str, &i, mini));
-// 		else // normal char
-// 			result = ft_strjoin_f(result, ft_strndup(str + i++, 1));
-// 	}
-// 	return (result);
-// }
-//char	*expand_arg(const char *str, t_mini *mini)
 char *expand_arg(const char *str, t_mini *mini, t_quote_type quote_type)
 {
 	char	*result;
@@ -139,7 +109,7 @@ char *expand_arg(const char *str, t_mini *mini, t_quote_type quote_type)
 			{
 				if (str[i] == '$')
 				{
-					// 處理 $"" 或 $'' 作為空字串
+					//處理 $"" 或 $'' 作為空字串
 					if (str[i + 1] == '"' && str[i + 2] == '"')
 						i += 3;
 					else if (str[i + 1] == '\'' && str[i + 2] == '\'')
@@ -166,36 +136,6 @@ char *expand_arg(const char *str, t_mini *mini, t_quote_type quote_type)
 		else // 普通字元
 			result = ft_strjoin_f(result, ft_strndup(str + i++, 1));
 	}
+	result = ft_strjoin_f(result, ft_strdup(""));
 	return (result);
 }
-
-/*
-char	*expand_arg(const char *str, t_mini *mini)
-{
-	char	*result;
-	int		i;
-
-	i = 0;
-	result = calloc(1, sizeof(char));
-	while (str[i])
-	{
-		if (str[i] == '"')
-		{
-			i++;
-			while (str[i] && str[i] != '"')
-			{
-				if (str[i] == '$')
-					result = ft_strjoin_f(result, expand_var(str, &i, mini));
-				else
-					result = ft_strjoin_f(result, ft_strndup(str + i++, 1));
-			}
-			if (str[i] == '"')
-				i++;
-		}
-		else if (str[i] == '$')
-			result = ft_strjoin_f(result, expand_var(str, &i, mini));
-		else
-			result = ft_strjoin_f(result, ft_strndup(str + i++, 1));
-	}
-	return (result);
-} */

--- a/src/expand/expand_arg_HOME.c
+++ b/src/expand/expand_arg_HOME.c
@@ -1,0 +1,91 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_arg.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/08 11:20:26 by hho-troc          #+#    #+#             */
+/*   Updated: 2025/05/08 11:20:33 by hho-troc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+char *ft_strjoin_f(char *s1, char *s2)
+{
+	char *joined = ft_strjoin(s1, s2);
+	free(s1);
+	return (joined);
+}
+
+char *get_env_value(const char *key, char **env)
+{
+	int i = 0;
+	size_t key_len = ft_strlen(key);
+
+	while (env[i])
+	{
+		if (!ft_strncmp(env[i], key, key_len) && env[i][key_len] == '=')
+			return (ft_strdup(env[i] + key_len + 1));
+		i++;
+	}
+	return (ft_strdup(""));
+}
+
+static char *expand_var(const char *str, int *i, t_mini *mini)
+{
+	int start = ++(*i);
+	char *var, *val;
+
+	if (str[start] == '?')
+	{
+		(*i)++;
+		return (ft_itoa(mini->last_exit));
+	}
+	if (!str[start] || !(ft_isalpha(str[start]) || str[start] == '_'))
+		return (ft_strdup("$"));
+	while (str[*i] && (ft_isalnum(str[*i]) || str[*i] == '_'))
+		(*i)++;
+	var = ft_strndup(str + start, *i - start);
+	val = get_env_value(var, mini->env);
+	free(var);
+	return (val);
+}
+
+static void handle_dollar(const char *str, int *i, char **res, t_mini *mini)
+{
+	char *val = expand_var(str, i, mini);
+	*res = ft_strjoin_f(*res, val);
+}
+
+static void append_plain(const char *str, int *i, char **res)
+{
+	int start = *i;
+
+	while (str[*i] && str[*i] != '$')
+		(*i)++;
+	*res = ft_strjoin_f(*res, ft_strndup(str + start, *i - start));
+}
+
+char *expand_arg(const char *str, t_mini *mini, t_quote_type quote_type)
+{
+	char *res = ft_strdup("");
+	int i = 0;
+
+	while (str[i])
+	{
+		if (str[i] == '$' && quote_type != QUOTE_SINGLE)
+			handle_dollar(str, &i, &res, mini);
+		else
+			append_plain(str, &i, &res);
+	}
+	return (res);
+}
+
+char *expand_if_needed(t_token *token, t_mini *mini)
+{
+	if (token->quote_type == QUOTE_SINGLE)
+		return (ft_strdup(token->str));
+	return expand_arg(token->str, mini, token->quote_type);
+}

--- a/src/init_ast.c
+++ b/src/init_ast.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/22 13:05:22 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/05/07 15:46:46 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/08 11:35:21 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,32 +32,6 @@ static int	add_split(char **args, int i, char *expanded)
 	return (i);
 }
 
-//for echo abcd"$USER"efgh, is not 3 arg, is one TO REMOVE
-// char	*merge_and_expand(t_token **current, t_token *end, t_mini *mini)
-// {
-// 	char	*result;
-// 	char	*part;
-// 	t_token	*tok;
-
-// 	result = ft_strdup("");
-// 	tok = *current;
-
-// 	while (tok && tok != end && (tok->type == CMD || tok->type == UNKNOWN))
-// 	{
-// 		if (tok->quote_type == QUOTE_SINGLE)
-// 			part = ft_strdup(tok->str);
-// 		else
-// 			part = expand_arg(tok->str, mini);
-// 		result = ft_strjoin_f(result, part);
-
-// 		tok = tok->next;
-// 		if (tok && (tok->type != CMD && tok->type != UNKNOWN))
-// 			break ;
-// 	}
-// 	*current = tok;
-
-// 	return (result);
-// }
 
 static int	handle_expanded(char **args, int i, t_token *tok, t_mini *mini)
 {
@@ -73,21 +47,6 @@ static int	handle_expanded(char **args, int i, t_token *tok, t_mini *mini)
 		i = add_split(args, i, expanded);
 	return (i);
 }
-
-/* replace for the condition "'$USER'"
-static int	handle_expanded(char **args, int i, t_token *tok, t_mini *mini)
-{
-	char	*expanded;
-
-	expanded = expand_arg(tok->str, mini);
-	if (!expanded)
-		return (i);
-	if (tok->quote_type == QUOTE_DOUBLE)
-		args[i++] = expanded;
-	else
-		i = add_split(args, i, expanded);
-	return (i);
-} */
 
 static int	process_token(char **args, int i, t_token *tok, t_mini *mini)
 {

--- a/src/init_ast.c
+++ b/src/init_ast.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/22 13:05:22 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/04/29 14:52:24 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/07 15:46:46 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,32 +32,32 @@ static int	add_split(char **args, int i, char *expanded)
 	return (i);
 }
 
-//for echo abcd"$USER"efgh, is not 3 arg, is one
-char	*merge_and_expand(t_token **current, t_token *end, t_mini *mini)
-{
-	char	*result;
-	char	*part;
-	t_token	*tok;
+//for echo abcd"$USER"efgh, is not 3 arg, is one TO REMOVE
+// char	*merge_and_expand(t_token **current, t_token *end, t_mini *mini)
+// {
+// 	char	*result;
+// 	char	*part;
+// 	t_token	*tok;
 
-	result = ft_strdup("");
-	tok = *current;
+// 	result = ft_strdup("");
+// 	tok = *current;
 
-	while (tok && tok != end && (tok->type == CMD || tok->type == UNKNOWN))
-	{
-		if (tok->quote_type == QUOTE_SINGLE)
-			part = ft_strdup(tok->str);
-		else
-			part = expand_arg(tok->str, mini);
-		result = ft_strjoin_f(result, part);
+// 	while (tok && tok != end && (tok->type == CMD || tok->type == UNKNOWN))
+// 	{
+// 		if (tok->quote_type == QUOTE_SINGLE)
+// 			part = ft_strdup(tok->str);
+// 		else
+// 			part = expand_arg(tok->str, mini);
+// 		result = ft_strjoin_f(result, part);
 
-		tok = tok->next;
-		if (tok && (tok->type != CMD && tok->type != UNKNOWN))
-			break ;
-	}
-	*current = tok;
+// 		tok = tok->next;
+// 		if (tok && (tok->type != CMD && tok->type != UNKNOWN))
+// 			break ;
+// 	}
+// 	*current = tok;
 
-	return (result);
-}
+// 	return (result);
+// }
 
 static int	handle_expanded(char **args, int i, t_token *tok, t_mini *mini)
 {
@@ -162,14 +162,14 @@ t_cmd	*build_command(t_token *start, t_token *end, t_mini *mini)
 			if (cmd->infile)
 				free(cmd->infile);
 			cmd->last_redirin = 0;
-			cmd->infile = expand_arg(tmp->next->str, mini);
+			cmd->infile = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			tmp = tmp->next;
 		}
 		else if (tmp->type == REDIR_OUT && tmp->next)
 		{
 			if (cmd->outfile)
 				free(cmd->outfile);
-			cmd->outfile = expand_arg(tmp->next->str, mini);
+			cmd->outfile = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			fd = open(cmd->outfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 			if (fd < 0)
 				exit_error("creation outfile");
@@ -181,10 +181,10 @@ t_cmd	*build_command(t_token *start, t_token *end, t_mini *mini)
 		{
 			if (cmd->outfile)
 				free(cmd->outfile);
-			cmd->outfile = expand_arg(tmp->next->str, mini);
+			cmd->outfile = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			if (cmd->append)
 				free(cmd->append);
-			cmd->append = expand_arg(tmp->next->str, mini);
+			cmd->append = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			fd = open(cmd->outfile, O_WRONLY | O_CREAT | O_APPEND, 0644);
 			if (fd < 0)
 				exit_error("append creation outfile");
@@ -197,7 +197,7 @@ t_cmd	*build_command(t_token *start, t_token *end, t_mini *mini)
 			if (cmd->infile)
 				free(cmd->infile);
 			cmd->last_redirin = 1;
-			cmd->infile = expand_arg(tmp->next->str, mini);
+			cmd->infile = expand_arg(tmp->next->str, mini, tmp->next->quote_type);
 			heredoc_nb++;
 			tmp = tmp->next;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 17:20:31 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/04/30 18:21:20 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/07 14:39:22 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,7 @@ static int	check_line(char *line, t_mini *mini)
 		return (0);
 	}
 	mini->token = tokenize_input(line);
+	print_token_list(mini->token);
 	if (!mini->token || !check_syntax(mini->token))
 	{
 		mini->last_exit = 2;

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -84,10 +84,10 @@ void	print_tab(char **tab)
 void	print_mini(t_mini *mini)
 {
 	t_token	*tmp;
-	t_ast	*tmp_ast;
+	//t_ast	*tmp_ast;
 
 	tmp = mini->token;
-	tmp_ast = mini->ast;
+	//tmp_ast = mini->ast;
 	printf("Mini %p\n", tmp);
 	while (tmp)
 	{

--- a/src/tokenizing/extract_quoted.c
+++ b/src/tokenizing/extract_quoted.c
@@ -1,0 +1,67 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   extract_quoted.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/08 20:52:58 by hho-troc          #+#    #+#             */
+/*   Updated: 2025/05/08 21:01:47 by hho-troc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+static int	get_quote_len(const char *input, int start, char quote)
+{
+	int	i;
+
+	i = start;
+	while (input[i] && input[i] != quote)
+		i++;
+	return (i - start);
+}
+
+static void	set_quote_type(char quote, t_quote_type *qt)
+{
+	if (quote == '"')
+		*qt = QUOTE_DOUBLE;
+	else if (quote == '\'')
+		*qt = QUOTE_SINGLE;
+}
+
+static int	should_strip_quotes(const char *input, int i, const char *current)
+{
+	return (current[0] == '\0'
+		&& (input[i] == '\0' || ft_isspace(input[i]) || is_meta_char(input[i])));
+}
+
+char	*extract_quoted(const char *input, int *i,
+						char *current, t_quote_type *qt)
+{
+	char	quote;
+	int		start;
+	int		len;
+	int		strip;
+	char	*quoted;
+
+	quote = input[(*i)++];
+	start = *i;
+	len = get_quote_len(input, start, quote);
+	if (input[*i + len] == quote)
+		*i += len + 1;
+	else
+		*i += len;
+	strip = should_strip_quotes(input, *i, current);
+	if (strip)
+	{
+		quoted = ft_strndup(&input[start], len);
+		set_quote_type(quote, qt);
+	}
+	else
+	{
+		quoted = ft_strndup(&input[start - 1], len + 2);
+		*qt = QUOTE_NONE;
+	}
+	return (ft_strjoin_f(current, quoted));
+}

--- a/src/tokenizing/helper.c
+++ b/src/tokenizing/helper.c
@@ -1,0 +1,67 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   helper.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/08 20:41:56 by hho-troc          #+#    #+#             */
+/*   Updated: 2025/05/08 21:00:01 by hho-troc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+int	is_meta_char(char c)
+{
+	return (c == '|' || c == '<' || c == '>');
+}
+
+void	skip_spaces(const char *input, int *i)
+{
+	while (input[*i] && ft_isspace(input[*i]))
+		(*i)++;
+}
+/* too long, seperate in extract_quote.c */
+// char	*extract_quoted(const char *input, int *i, char *current, t_quote_type *qt)
+// {
+// 	char quote = input[(*i)++];
+// 	int start = *i;
+// 	int is_wrapped = (current[0] == '\0');
+// 	while (input[*i] && input[*i] != quote)
+// 		(*i)++;
+// 	int len = *i - start;
+// 	if (input[*i] == quote)
+// 		(*i)++;
+// 	char *quoted;
+// 	if (is_wrapped && (input[*i] == '\0' || ft_isspace(input[*i]) || is_meta_char(input[*i])))
+// 	{
+// 		quoted = ft_strndup(&input[start], len);
+// 		*qt = (quote == '"') ? QUOTE_DOUBLE : QUOTE_SINGLE;
+// 	}
+// 	else
+// 	{
+// 		quoted = ft_strndup(&input[start - 1], len + 2);
+// 		*qt = QUOTE_NONE;
+// 	}
+// 	return ft_strjoin_f(current, quoted);
+// }
+
+char	*extract_plain(const char *input, int *i, char *current)
+{
+	int	start;
+
+	start = *i;
+	while (input[*i] && !ft_isspace(input[*i]) && \
+		input[*i] != '"' && input[*i] != '\'' && \
+		!is_meta_char(input[*i]))
+		(*i)++;
+	return (ft_strjoin_f(current, ft_strndup(&input[start], *i - start)));
+}
+
+int	handle_meta(const char *input, int i, t_token **tokens)
+{
+	int len = (input[i] == input[i + 1]) ? 2 : 1;
+	append_t(tokens, create_t(ft_strndup(&input[i], len), QUOTE_NONE));
+	return (i + len);
+}

--- a/src/tokenizing/token.c
+++ b/src/tokenizing/token.c
@@ -6,36 +6,11 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/25 12:33:52 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/04/30 14:33:06 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/07 15:51:02 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
-/* remove to keep asb"$USER"ecd as one arg
-static int	process_quoted_token(const char *input, int i, t_token **tokens)
-{
-	char	quote;
-	int		start;
-
-	quote = input[i];
-	start = ++i;
-	while (input[i] && input[i] != quote)
-		i++;
-	if (input[i] == quote)
-	{
-		if (quote == '\'')
-			append_t(tokens, \
-				create_t(ft_strndup(&input[start], i - start), QUOTE_SINGLE));
-		else
-			append_t(tokens, \
-				create_t(ft_strndup(&input[start], i - start), QUOTE_DOUBLE));
-		return (i + 1);
-	}
-	//if quote is not in pair, we put QUOTE_NONE in the moment //
-	append_t(tokens, \
-		create_t(ft_strndup(&input[start - 1], i - start + 1), QUOTE_NONE));
-	return (i);
-} */
 
 static int	process_redirection(const char *input, int i, t_token **tokens)
 {
@@ -48,60 +23,11 @@ static int	process_redirection(const char *input, int i, t_token **tokens)
 	return (i + len);
 }
 
-/* static int	process_token(const char *input, int i, t_token **tokens)
-{
-	char	*token_str = calloc(1, sizeof(char));
-	char	*part;
-	int		start;
-	char	quote;
-
-	// ✅ 處理 redirection（> >> < <<）
-	if (input[i] == '>' || input[i] == '<')
-		return process_redirection(input, i, tokens);
-
-	// ✅ 處理 pipe
-	if (input[i] == '|')
-	{
-		append_t(tokens, create_t(ft_strndup(&input[i], 1), QUOTE_NONE));
-		return i + 1;
-	}
-
-	// ✅ 主體：組合 quoted/unquoted 為單一 token
-	while (input[i] && !ft_isspace(input[i]) && input[i] != '|' && input[i] != '<' && input[i] != '>')
-	{
-		if (input[i] == '"' || input[i] == '\'')
-		{
-			quote = input[i++];
-			start = i;
-			while (input[i] && input[i] != quote)
-				i++;
-			part = ft_strndup(input + start, i - start); // 提取 quote 內容
-			token_str = ft_strjoin_f(token_str, part);
-			if (input[i] == quote)
-				i++; // skip closing quote
-		}
-		else
-		{
-			start = i;
-			while (input[i] && input[i] != '"' && input[i] != '\'' &&
-				!ft_isspace(input[i]) && input[i] != '|' && input[i] != '<' && input[i] != '>')
-				i++;
-			part = ft_strndup(input + start, i - start);
-			token_str = ft_strjoin_f(token_str, part);
-		}
-	}
-
-	append_t(tokens, create_t(token_str, QUOTE_NONE));
-	return i;
-} */
-
-
-
-//for empty, version not take quote into account//
 static int	process_token(const char *input, int i, t_token **tokens)
 {
-	int	start;
+	int		start;
 	char	quote;
+	char	*content;
 
 	if (input[i] == '>' || input[i] == '<')
 		return (process_redirection(input, i, tokens));
@@ -109,55 +35,29 @@ static int	process_token(const char *input, int i, t_token **tokens)
 	{
 		append_t(tokens, create_t(ft_strndup(&input[i], 1), QUOTE_NONE));
 		return (i + 1);
+	}
+	else if (input[i] == '"' || input[i] == '\'')
+	{
+		quote = input[i++];
+		start = i;
+		while (input[i] && input[i] != quote)
+			i++;
+		content = ft_strndup(input + start, i - start);
+		if (input[i] == quote)
+			i++;
+		append_t(tokens, create_t(content, quote == '"' ? QUOTE_DOUBLE : QUOTE_SINGLE));
+		return (i);
 	}
 	else
 	{
 		start = i;
 		while (input[i] && !ft_isspace(input[i]) && input[i] != '|' && input[i] != '<' && input[i] != '>')
-		{
-			if (input[i] == '\'' || input[i] == '"')
-			{
-				quote = input[i++];
-				while (input[i] && input[i] != quote)
-					i++;
-				if (input[i] == quote)
-					i++; // skip closing quote
-			}
-			else
-				i++;
-		}
+			i++;
 		append_t(tokens, create_t(ft_strndup(&input[start], i - start), QUOTE_NONE));
 		return (i);
 	}
 }
-/* static int	process_token(const char *input, int i, t_token **tokens)
-{
-	int	start;
 
-	if ((input[i] == '"' || input[i] == '\'') && find_matching_quote(&input[i]))
-	//if ((input[i] == '"') && find_matching_quote(&input[i]))
-		return (process_quoted_token(input, i, tokens));
-	else if (input[i] == '>' || input[i] == '<')
-		return (process_redirection(input, i, tokens));
-	else if (input[i] == '|')
-	{
-		append_t(tokens, create_t(ft_strndup(&input[i], 1), QUOTE_NONE));
-		return (i + 1);
-	}
-	else
-	{
-		start = i;
-		// while (input[i] && !ft_isspace(input[i])
-		// 	&& input[i] != '|' && input[i] != '<' && input[i] != '>')
-		while (input[i] && !ft_isspace(input[i])
-			&& input[i] != '|' && input[i] != '<' && input[i] != '>'
-			&& input[i] != '"' && input[i] != '\'')
-			i++;
-		append_t(tokens, \
-			create_t(ft_strndup(&input[start], i - start), QUOTE_NONE));
-		return (i);
-	}
-} */
 
 //for ""empty
 t_token	*tokenize_input(const char *input)
@@ -193,24 +93,7 @@ t_token	*tokenize_input(const char *input)
 
 	return tokens;
 }
-/*
-t_token	*tokenize_input(const char *input)
-{
-	t_token	*tokens;
-	int		i;
 
-	tokens = NULL;
-	i = 0;
-	while (input[i])
-	{
-		while (ft_isspace(input[i]))
-			i++;
-		if (!input[i])
-			break ;
-		i = process_token(input, i, &tokens);
-	}
-	return (tokens);
-} */
 void	print_token_list(t_token *token)
 {
 	while (token)

--- a/src/tokenizing/token_57.c
+++ b/src/tokenizing/token_57.c
@@ -1,0 +1,108 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   token_57.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/25 12:33:52 by hho-troc          #+#    #+#             */
+/*   Updated: 2025/05/08 12:29:16 by hho-troc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+/* V0507, problem whil "" at begining of cmd line */
+static int	process_redirection(const char *input, int i, t_token **tokens)
+{
+	int	len;
+
+	len = 1;
+	if (input[i] == input[i + 1])
+		len = 2;
+	append_t(tokens, create_t(ft_strndup(&input[i], len), QUOTE_NONE));
+	return (i + len);
+}
+
+static int	process_token(const char *input, int i, t_token **tokens)
+{
+	int		start;
+	char	quote;
+	char	*content;
+
+	if (input[i] == '>' || input[i] == '<')
+		return (process_redirection(input, i, tokens));
+	else if (input[i] == '|')
+	{
+		append_t(tokens, create_t(ft_strndup(&input[i], 1), QUOTE_NONE));
+		return (i + 1);
+	}
+	else if (input[i] == '"' || input[i] == '\'')
+	{
+		quote = input[i++];
+		start = i;
+		while (input[i] && input[i] != quote)
+			i++;
+		content = ft_strndup(input + start, i - start);
+		if (input[i] == quote)
+			i++;
+		append_t(tokens, create_t(content, quote == '"' ? QUOTE_DOUBLE : QUOTE_SINGLE));
+		return (i);
+	}
+	else
+	{
+		start = i;
+		while (input[i] && !ft_isspace(input[i]) && input[i] != '|' && input[i] != '<' && input[i] != '>')
+			i++;
+		append_t(tokens, create_t(ft_strndup(&input[start], i - start), QUOTE_NONE));
+		return (i);
+	}
+}
+
+
+//for ""empty, but not work for """"echo hola""", permission denied
+t_token	*tokenize_input(const char *input)
+{
+	t_quote_type qt;
+	t_token	*tokens;
+	int		i;
+
+	tokens = NULL;
+	i = 0;
+	while (input[i])
+	{
+		while (ft_isspace(input[i]))
+			i++;
+
+		if (!input[i])
+			break;
+
+		// Special case: "" or '' (empty string token)
+		if ((input[i] == '"' && input[i + 1] == '"' && input[i + 2] == ' ') ||
+			(input[i] == '\'' && input[i + 1] == '\'' && input[i + 2] == ' '))
+		{
+			if (input[i] == '"')
+				qt = QUOTE_DOUBLE;
+			else
+				qt = QUOTE_SINGLE;
+			i += 2;
+			append_t(&tokens, create_t(ft_strdup(""), qt));
+			continue;
+		}
+		i = process_token(input, i, &tokens);
+	}
+
+	return tokens;
+}
+
+
+
+
+void	print_token_list(t_token *token)
+{
+	while (token)
+	{
+		printf("Token: [%s], quote_type: %d\n",
+			token->str[0] ? token->str : "(empty)", token->quote_type);
+		token = token->next;
+	}
+}

--- a/src/tokenizing/token_utils.c
+++ b/src/tokenizing/token_utils.c
@@ -6,7 +6,7 @@
 /*   By: hho-troc <hho-troc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/25 12:37:11 by hho-troc          #+#    #+#             */
-/*   Updated: 2025/04/25 12:58:39 by hho-troc         ###   ########.fr       */
+/*   Updated: 2025/05/07 14:37:58 by hho-troc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,17 +78,3 @@ void	print_token_list(t_token *token)
 		token = token->next;
 	}
 } */
-/* int	main(void)
-{
-	//t_token *tokens = tokenize_input\
-	("echo \"hello | world\" > output.txt | cat -e");
-	//t_token *tokens = tokenize_input\
-	("echo hello | world >>>> output.txt | cat -e");
-	t_token *tokens = tokenize_input\
-	("echo hello | world > > > > output.txt | cat -e");
-	print_token_list(tokens);
-	free_token_list(tokens);
-	return(0);
-}
-
- */


### PR DESCRIPTION
change the prototype 
FROM: char	*expand_arg(const char *str, t_mini *mini); 
TO char *expand_arg(const char *str, t_mini *mini, **t_quote_type quote_type)**;, 
Here I add quote type to indicate clearer the rule of expand.
---------**OK**----

1.  echo "     " | cat -e (add today, modify token.c and expand_arg)
2.  echo $ (add today, change in expand.c)
3. echo "" "" "" abc"$USER"
4. echo "'$USER'" (bonus test)

and other normal situation like echo "'$HOME'" in the list...... etc
--------**Not Solve**----

1.  ""''echo hola""'''' que""'' tal""''->our program  takes empty"" as an invalide cmd
2. echo ""$USER"" -> in bash it's hho-troc WITHOUT space at beginning

Those tow situations are very tricky, 
 [echo "" "" "" abc], the "" will consider as one space, but in [echo ""$USER""], the bash WON'T print the space, I will try to find a solution which can keep BOTH [""] situation works.
For  ""''echo hola""'''' que""'' tal""'', I'm trying 2 solutions, one is "skip empty token at beginning" ; another is , redo process_token to make [""""echo] as ONE token insted of several token ['' + '' + echo]
BUT, both of 2 solution product problems and make the test was OK in KO......(because they'll change the arg_count and crush the old rule)

I'll continue to fix and test ! 

